### PR TITLE
Update prestashop-academy.com URLs to care-center.prestashop.com

### DIFF
--- a/install-theme/footer.php
+++ b/install-theme/footer.php
@@ -5,7 +5,7 @@ include_once _PS_INSTALL_PATH_ . '/theme/views/footer.php';
     <?php echo $this->translator->trans('Any questions? We’re here to help. Visit the [1]Help Center[/1] or [2]contact us[/2].', [
         '[1]' => '<a href="https://help-center.prestashop.com/" target="_blank" rel="noopener noreferrer">',
         '[/1]' => '</a>',
-        '[2]' => '<a href="https://prestashop-academy.com/contact-us" target="_blank" rel="noopener noreferrer">',
+        '[2]' => '<a href="https://care-center.prestashop.com/contact-us" target="_blank" rel="noopener noreferrer">',
         '[/2]' => '</a>',
     ], 'Install'); ?>
 </div>

--- a/src/Controller/AdminPsClassicEditionPsAcademyController.php
+++ b/src/Controller/AdminPsClassicEditionPsAcademyController.php
@@ -59,7 +59,7 @@ class AdminPsClassicEditionPsAcademyController extends PrestaShopAdminController
 
             if (!empty($ids)) {
                 foreach ($ids as $id) {
-                    $response = $this->httpClient->request('GET', 'https://prestashop-academy.com/api/products/' . $id . '?ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON&id_lang=' . $psAcademyLangId);
+                    $response = $this->httpClient->request('GET', 'https://care-center.prestashop.com/api/products/' . $id . '?ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON&id_lang=' . $psAcademyLangId);
                     $httpStatusCode = $response->getStatusCode();
                     if ($httpStatusCode <= 300) {
                         $responseContents = json_decode($response->getContent(), true);
@@ -85,11 +85,11 @@ class AdminPsClassicEditionPsAcademyController extends PrestaShopAdminController
     {
         $responseVideoHosted = $this->httpClient->request(
             'GET',
-            'https://prestashop-academy.com/api/products?filter[mpn]=[videoHosted]&ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON&id_lang=' . $psAcademyLangId,
+            'https://care-center.prestashop.com/api/products?filter[mpn]=[videoHosted]&ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON&id_lang=' . $psAcademyLangId,
         );
         $responseLiveHosted = $this->httpClient->request(
             'GET',
-            'https://prestashop-academy.com/api/products?filter[mpn]=[liveHosted]&ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON&id_lang=' . $psAcademyLangId,
+            'https://care-center.prestashop.com/api/products?filter[mpn]=[liveHosted]&ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON&id_lang=' . $psAcademyLangId,
         );
 
         $responseContentsVideoHosted = json_decode($responseVideoHosted->getContent(), true);
@@ -125,7 +125,7 @@ class AdminPsClassicEditionPsAcademyController extends PrestaShopAdminController
             'it' => 3,
         ];
 
-        $responseCategory = $this->httpClient->request('GET', 'https://prestashop-academy.com/api/categories/' . $response['id_category_default'] . '?ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON');
+        $responseCategory = $this->httpClient->request('GET', 'https://care-center.prestashop.com/api/categories/' . $response['id_category_default'] . '?ws_key=QG8Z1KD7HAYMAPKK1FR2DKXUIF9LTRJE&output_format=JSON');
         $httpStatusCode = $responseCategory->getStatusCode();
 
         if ($httpStatusCode > 300) {
@@ -134,7 +134,7 @@ class AdminPsClassicEditionPsAcademyController extends PrestaShopAdminController
         $responseContents = json_decode($responseCategory->getContent(), true);
         $category = $responseContents['category']['link_rewrite'][$langIds[$locale]]['value'];
         $link_rewrite = $response['link_rewrite'][$langIds[$locale]]['value'];
-        $productUrl = 'https://prestashop-academy.com/' . $locale . '/' . $category . '/' . $response['id'] . '-' . $link_rewrite . '.html';
+        $productUrl = 'https://care-center.prestashop.com/' . $locale . '/' . $category . '/' . $response['id'] . '-' . $link_rewrite . '.html';
 
         $tmp = [
             'name' => $response['name'][$langIds[$locale]]['value'],

--- a/vue-app/src/locales/en.json
+++ b/vue-app/src/locales/en.json
@@ -137,7 +137,7 @@
         "title": "Need some assistance?",
         "description": "Don't hesitate to contact our support team.",
         "button": "Contact Us",
-        "url": "https://prestashop-academy.com/gb/contact-us"
+        "url": "https://care-center.prestashop.com/gb/contact-us"
       },
       "update-modal": {
         "update-running": "Update in progress",

--- a/vue-app/src/locales/es.json
+++ b/vue-app/src/locales/es.json
@@ -137,7 +137,7 @@
         "title": "¿Necesita ayuda?",
         "description": "No dude en contactar con nuestro equipo de soporte.",
         "button": "Póngase en contacto con nosotros",
-        "url": "https://prestashop-academy.com/es/contactenos"
+        "url": "https://care-center.prestashop.com/es/contactenos"
       },
       "update-modal": {
         "update-running": "Actualización en progreso",

--- a/vue-app/src/locales/fr.json
+++ b/vue-app/src/locales/fr.json
@@ -137,7 +137,7 @@
         "title": "Besoin d'assistance?",
         "description": "N'hésitez pas à contacter notre équipe de support",
         "button": "Contactez-nous",
-        "url": "https://prestashop-academy.com/fr/nous-contacter"
+        "url": "https://care-center.prestashop.com/fr/nous-contacter"
       },
       "update-modal": {
         "update-running": "Mise à jour en cours",

--- a/vue-app/src/locales/it.json
+++ b/vue-app/src/locales/it.json
@@ -137,7 +137,7 @@
         "title": "Hai bisogno di assistenza?",
         "description": "Non esitate a contattare il nostro team di supporto.",
         "button": "Contattateci",
-        "url": "https://prestashop-academy.com/it/contattaci"
+        "url": "https://care-center.prestashop.com/it/contattaci"
       },
       "update-modal": {
         "update-running": "Aggiornamento in corso",

--- a/vue-app/src/modules/Onboarding/components/PsAcademy/PsAcademy.vue
+++ b/vue-app/src/modules/Onboarding/components/PsAcademy/PsAcademy.vue
@@ -8,7 +8,7 @@ const { context } = useContext();
 const psAcademyStore = usePsAcademy();
 const { sortedProducts, pages, loading } = storeToRefs(psAcademyStore);
 
-const psAcademyUrl = "https://prestashop-academy.com/";
+const psAcademyUrl = "https://care-center.prestashop.com/";
 
 const currentIndex = ref(0);
 /**


### PR DESCRIPTION
## 🔧 Fix: Update Academy URLs

This PR updates all references from `prestashop-academy.com` to `care-center.prestashop.com` across the codebase.

### 📋 Changes Made

- **API Endpoints**: Updated all API calls in `AdminPsClassicEditionPsAcademyController.php`
  - Product API endpoints
  - Category API endpoints  
  - Product URL generation

- **Contact URLs**: Updated contact links in all locale files
  - English (`en.json`)
  - Spanish (`es.json`) 
  - French (`fr.json`)
  - Italian (`it.json`)

- **Component URLs**: Updated base URL in `PsAcademy.vue` component

- **Install Theme**: Updated contact link in footer template

**Resolves #97**